### PR TITLE
fixes for new version of l20n

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -11,7 +11,7 @@
     "bower_components"
   ],
   "dependencies": {
-    "l20n": "^3.0.5",
+    "l20n": "^3.2.0",
     "bootstrap": "^3.3.5",
     "bootstrap-material-design": "^0.3.0",
     "localforage": "^1.2.7",

--- a/public/js/main.js
+++ b/public/js/main.js
@@ -8,7 +8,7 @@
  */
 (function() {
   'use strict';
-  document.addEventListener('DOMLocalized', function() { // l20n ready
+  document.l10n.ready.then(function() { // l20n ready
     document.body.classList.remove('hidden');
     $.material.ripples();
     // document.addEventListener('deviceready',

--- a/views/main.html
+++ b/views/main.html
@@ -21,7 +21,7 @@
     <!--[if IE]><link rel="shortcut icon" href="style/icons/favicon.ico"  type="image/x-icon"><![endif]-->
     <meta name="defaultLanguage" content="en-US">
     <meta name="availableLanguages" content="en-US, zh-TW">
-    <link rel="localization" href="locales/locales.{locale}.l20n">
+    <link rel="localization" href="public/locales/locales.{locale}.l20n">
     <script defer src="public/vendor/l20n/dist/webcompat/l20n.js"></script>
 
     <link rel="stylesheet" href="public/vendor/bootstrap/dist/css/bootstrap.min.css">


### PR DESCRIPTION
- as l20n with "^3.0.5" within bower.js loads "3.2.0", the initialization needs to be adapted
  - changed from DOMLocalized event to document.l10n.ready promise
- fixed loading of locales for dynamic web apps in views/main.html
